### PR TITLE
Removed unused gem danger-auto_label

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,6 @@ gem 'cocoapods', '~> 1.10'
 # ------------
 gem 'danger'
 
-# github
-gem 'danger-auto_label'
-
 # general
 gem 'danger-todoist'
 gem 'danger-prose'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,6 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    danger-auto_label (1.3.1)
-      danger-plugin-api (~> 1.0)
     danger-jazzy (1.1.0)
       danger-plugin-api (~> 1.0)
       json (~> 2.1.0)
@@ -173,7 +171,6 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (~> 1.10)
   danger
-  danger-auto_label
   danger-jazzy
   danger-prose
   danger-swiftlint


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/jessesquires/.github/blob/master/CONTRIBUTING.md)?*

Issue #

## Describe your changes

Removed unused gem danger-auto_label